### PR TITLE
Updated with better documentation and improved tests.

### DIFF
--- a/Warmups.BLL/Docs/Logic/02 - CanHazTable.txt
+++ b/Warmups.BLL/Docs/Logic/02 - CanHazTable.txt
@@ -1,4 +1,4 @@
-You and your date are trying to get a table at a restaurant. The parameter "you" is the stylishness of your clothes, in the range 0..10, and "date" is the stylishness of your date's clothes. The result getting the table is encoded as an int value with 0=no, 1=maybe, 2=yes. If either of you is very stylish, 8 or more, then the result is 2 (yes). With the exception that if either of you has style of 2 or less, then the result is 0 (no). Otherwise the result is 1 (maybe). 
+You and your date are trying to get a table at a restaurant. The parameter "yourstyle" is the stylishness of your clothes, in the range 0..10, and "dateStyle" is the stylishness of your date's clothes. The result getting the table is encoded as an int value with 0=no, 1=maybe, 2=yes. If either of you is very stylish, 8 or more, then the result is 2 (yes). With the exception that if either of you has style of 2 or less, then the result is 0 (no). Otherwise the result is 1 (maybe). 
 
 CanHazTable(5, 10) → 2
 CanHazTable(5, 2) → 0

--- a/Warmups.BLL/Docs/Logic/03 - PlayOutside.txt
+++ b/Warmups.BLL/Docs/Logic/03 - PlayOutside.txt
@@ -1,4 +1,4 @@
-The children in Cleveland spend most of the day playing outside. In particular, they play if the temperature is between 60 and 90 (inclusive). Unless it is summer, then the upper limit is 100 instead of 90. Given an int temperature and a boolean isSummer, return true if the children play and false otherwise. 
+The children in Cleveland spend most of the day playing outside. In particular, they play if the temperature is between 60 and 90 (inclusive). Unless it is summer, then the upper limit is 100 instead of 90. Given an int "temp" and a boolean "isSummer", return true if the children play and false otherwise. 
 
 PlayOutside(70, false) → true
 PlayOutside(95, false) → false

--- a/Warmups.BLL/Docs/Logic/10 - Mod20.txt
+++ b/Warmups.BLL/Docs/Logic/10 - Mod20.txt
@@ -1,4 +1,4 @@
-Return true if the given non-negative number is 1 or 2 more than a multiple of 20. See also: Introduction to Mod 
+Return true if the given non-negative number is 1 or 2 more than a multiple of 20.
 
 Mod20(20) → false
 Mod20(21) → true

--- a/Warmups.BLL/Docs/Strings/18 - LastChars.txt
+++ b/Warmups.BLL/Docs/Strings/18 - LastChars.txt
@@ -4,6 +4,6 @@ LastChars("last", "chars") -> "ls"
 LastChars("yo", "mama") -> "ya"
 LastChars("hi", "") -> "h@"
 
-public string LastChars(string str) {
+public string LastChars(string a, string b) {
 
 }

--- a/Warmups.Tests/ArrayTests.cs
+++ b/Warmups.Tests/ArrayTests.cs
@@ -26,7 +26,7 @@ namespace Warmups.Tests
             var actual = _arrays.SameFirstLast(nums);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(3, new[] { 3, 1, 4 })]
         [TestCase(1, new[] { 3 })]
         [TestCase(5, new[] { 3, 1, 4, 1, 5 })]
@@ -35,7 +35,7 @@ namespace Warmups.Tests
             var actual = _arrays.MakePi(n);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(new[] { 1, 2, 3 }, new[] { 7, 3 }, true)]
         [TestCase(new[] { 1, 2, 3 }, new[] { 7, 3, 2 }, false)]
         [TestCase(new[] { 1, 2, 3 }, new[] { 1, 3 }, true)]
@@ -44,7 +44,7 @@ namespace Warmups.Tests
             var actual = _arrays.CommonEnd(a, b);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(new[] { 1, 2, 3 }, 6)]
         [TestCase(new[] { 5, 11, 2 }, 18)]
         [TestCase(new[] { 7, 0, 0 }, 7)]
@@ -62,7 +62,7 @@ namespace Warmups.Tests
             var actual = _arrays.RotateLeft(nums);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(new[] { 1, 2, 3 }, new[] { 3, 2, 1 })]
         [TestCase(new[] { 5, 9, 11, 1 }, new[] { 1, 11, 9, 5 })]
         [TestCase(new[] { 7, 0, 0 }, new[] { 0, 0, 7 })]
@@ -139,6 +139,7 @@ namespace Warmups.Tests
         [TestCase(new[] { 4, 5 }, new[] { 1, 2, 3 }, new[] { 4, 5 })]
         [TestCase(new[] { 4 }, new[] { 1, 2, 3 }, new[] { 4, 1 })]
         [TestCase(new int[] { }, new[] { 1, 2 }, new[] { 1, 2 })]
+        [TestCase(new[] { 4, 5, 6 }, new[] { 1, 2, 3 }, new[] { 4, 5 })]
         public void Make2Test(int[] a, int[] b, int[] expected)
         {
             var actual = _arrays.Make2(a, b);

--- a/Warmups.Tests/ConditionalsTests.cs
+++ b/Warmups.Tests/ConditionalsTests.cs
@@ -17,7 +17,7 @@ namespace Warmups.Tests
             var actual = _conditionals.AreWeInTrouble(a, b);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(false, false, true)]
         [TestCase(true, false, false)]
         [TestCase(false, true, true)]
@@ -26,7 +26,7 @@ namespace Warmups.Tests
             var actual = _conditionals.CanSleepIn(a, b);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(1, 2, 3)]
         [TestCase(3, 2, 5)]
         [TestCase(2, 2, 8)]
@@ -35,7 +35,7 @@ namespace Warmups.Tests
             var actual = _conditionals.SumDouble(a, b);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(23, 4)]
         [TestCase(10, 11)]
         [TestCase(21, 0)]
@@ -75,6 +75,8 @@ namespace Warmups.Tests
         [TestCase(1, -1, false, true)]
         [TestCase(-1, 1, false, true)]
         [TestCase(-4, -5, true, true)]
+        [TestCase(-4, -5, false, false)]
+        [TestCase(1, 1, false, false)]
         public void PosNegTest(int x, int y, bool b, bool expected)
         {
             var actual = _conditionals.PosNeg(x, y, b);
@@ -196,6 +198,7 @@ namespace Warmups.Tests
         [TestCase("mix snacks", true)]
         [TestCase("pix snacks", true)]
         [TestCase("piz snacks", false)]
+        [TestCase("pixel", true)]
         public void IxStartTest(string str, bool expected)
         {
             var actual = _conditionals.IxStart(str);

--- a/Warmups.Tests/LogicTests.cs
+++ b/Warmups.Tests/LogicTests.cs
@@ -11,6 +11,7 @@ namespace Warmups.Tests
         [TestCase(30, false, false)]
         [TestCase(50, false, true)]
         [TestCase(70, true, true)]
+        [TestCase(20, true, false)]
         public void GreatPartyTest(int n, bool b, bool expected)
         {
             var actual = _logic.GreatParty(n, b);
@@ -25,7 +26,7 @@ namespace Warmups.Tests
             var actual = _logic.CanHazTable(x, y);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(70, false, true)]
         [TestCase(95, false, false)]
         [TestCase(95, true, true)]
@@ -88,7 +89,7 @@ namespace Warmups.Tests
             var actual = _logic.SpecialEleven(n);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(20, false)]
         [TestCase(21, true)]
         [TestCase(22, true)]
@@ -137,6 +138,7 @@ namespace Warmups.Tests
         [TestCase(2, 5, 11, false, true)]
         [TestCase(5, 7, 6, false, false)]
         [TestCase(5, 5, 7, true, true)]
+        [TestCase(6, 5, 5, true, false)]
         public void InOrderEqualTest(int x, int y, int z, bool b, bool expected)
         {
             var actual = _logic.InOrderEqual(x, y, z, b);
@@ -151,10 +153,11 @@ namespace Warmups.Tests
             var actual = _logic.LastDigit(x, y, z);
             Assert.AreEqual(expected, actual);
         }
-        
+
         [TestCase(2, 3, true, 5)]
         [TestCase(3, 3, true, 7)]
         [TestCase(3, 3, false, 6)]
+        [TestCase(6, 6, true, 7)]
         public void RollDiceTest(int x, int y, bool b, int expected)
         {
             var actual = _logic.RollDice(x, y, b);

--- a/Warmups.Tests/LoopsTests.cs
+++ b/Warmups.Tests/LoopsTests.cs
@@ -41,6 +41,7 @@ namespace Warmups.Tests
         [TestCase("dffa", false)]
         [TestCase("tx", false)]
         [TestCase("txx", true)]
+        [TestCase("x", false)]
         public void DoubleXTest(string str, bool expected)
         {
             var actual = _loops.DoubleX(str);
@@ -134,6 +135,7 @@ namespace Warmups.Tests
         [TestCase("yakpak", "pak")]
         [TestCase("pakyak", "pak")]
         [TestCase("yak123ya", "123ya")]
+        [TestCase("ybkpbk", "pbk")]
         public void DoNotYakTest(string str, string expected)
         {
             var actual = _loops.DoNotYak(str);

--- a/Warmups.Tests/Warmups.Tests.csproj
+++ b/Warmups.Tests/Warmups.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.2\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +13,8 @@
     <AssemblyName>Warmups.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.13.2.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.2\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -64,6 +67,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.2\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Warmups.Tests/packages.config
+++ b/Warmups.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="NUnit" version="3.13.2" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="4.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Arrays > Make2Test - Added this test to ensure someone doesn't hardcode check for length of array.

Conditionals > PosNegTest - Added two checks for both positive and both negative with "isNegative" set to false. 

Conditionals > IxStartTest - Added "pixel" test which starts with it but within a word.

Logic > GreatPartyTest - Checking for Weekend below min number of cigars

Logic > InOrderEqualTest - Ensuring validation where there are "equals" but also not in incrementing order

Logic > RollDiceTest - Ensuring rules around incrementing 1 and rolling one 6 to a 1 is tested. I believe this answer will correctly test the scenario described.

Loops > DoubleXTest - Testing for a single X

Loops > DoNotYakTest - Instructions state that the "a" in "yak" can be any character. Thus testing against "ybkpbk"

Also added NUnit Test Adapter and upgraded NUnit nuget package